### PR TITLE
SpaceWallTemporaryService의 delete 메서드를 EntityManager를 활용하여 리팩토링 완료

### DIFF
--- a/src/main/java/com/javajober/spaceWall/repository/SpaceWallRepository.java
+++ b/src/main/java/com/javajober/spaceWall/repository/SpaceWallRepository.java
@@ -13,8 +13,6 @@ import java.util.Optional;
 
 public interface SpaceWallRepository extends Repository<SpaceWall, Long> {
 
-    void deleteAll(List<SpaceWall> spaceWalls);
-
     SpaceWall save(final SpaceWall spaceWall);
 
     boolean existsByShareURL(final String shareURL);

--- a/src/main/java/com/javajober/spaceWall/service/SpaceWallTemporaryService.java
+++ b/src/main/java/com/javajober/spaceWall/service/SpaceWallTemporaryService.java
@@ -14,9 +14,11 @@ import java.util.List;
 public class SpaceWallTemporaryService {
 
     private final SpaceWallRepository spaceWallRepository;
+    private final EntityManager entityManager;
 
-    public SpaceWallTemporaryService(final SpaceWallRepository spaceWallRepository){
+    public SpaceWallTemporaryService(final SpaceWallRepository spaceWallRepository, final EntityManager entityManager){
         this.spaceWallRepository = spaceWallRepository;
+        this.entityManager = entityManager;
     }
 
     @Transactional
@@ -26,7 +28,7 @@ public class SpaceWallTemporaryService {
 
         spaceWalls.removeIf(spaceWall -> !spaceWall.getFlag().equals(FlagType.PENDING));
 
-        spaceWallRepository.deleteAll(spaceWalls);
+        spaceWalls.forEach(entityManager::remove);
     }
 
     public SpaceWallTemporaryResponse hasSpaceWallTemporary(final Long memberId, final Long addSpaceId) {


### PR DESCRIPTION
- 이전 코드에서는 SpaceWallRepository의 deleteAll 메서드를 활용하려 했으나, SpaceWallRepository가 JpaRepository를 확장하지 않아서 해당 메서드를 사용할 수 없는 문제가 발생. 오류 해결을 위해 EntityManager를 이용한 최적화로 변경. 
- SpaceWallRepository 대신 EntityManager를 사용하여 SpaceWall 엔티티를 일괄적으로 삭제