### PR TITLE
SpaceWallTemporary 삭제 쿼리 성능 최적화로 배포 환경 이슈 해결

### DIFF
--- a/src/main/java/com/javajober/spaceWall/repository/SpaceWallRepository.java
+++ b/src/main/java/com/javajober/spaceWall/repository/SpaceWallRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public interface SpaceWallRepository extends Repository<SpaceWall, Long> {
 
     @Modifying
-    @Query("DELETE FROM SpaceWall sw WHERE sw.id IN (SELECT s.id FROM SpaceWall s WHERE s.member.id = :memberId AND s.addSpace.id = :addSpaceId AND s.flag = :flag)")
+    @Query("DELETE FROM SpaceWall sw WHERE sw.member.id = :memberId AND sw.addSpace.id = :addSpaceId AND sw.flag = :flag")
     void deleteByMemberIdAndAddSpaceIdAndFlag(@Param("memberId") Long memberId, @Param("addSpaceId") Long addSpaceId, @Param("flag") FlagType flag);
 
     SpaceWall save(final SpaceWall spaceWall);


### PR DESCRIPTION
- #183 

- SpaceWall 삭제를 위한 JPA 쿼리에서 서브쿼리 대신 직접 조건문 사용으로 변경.
- 배포 환경에서의 삭제 성능 및 안정성 향상.
- 데이터베이스 처리 시간 단축 및 효율성 증가.
- 배포 환경과 로컬 환경에서의 일관된 동작 보장.